### PR TITLE
Added Cloud Seeder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
 
 ## Tools
 
+- [Cloud Seeder](https://ipv6.rs/cloudseeder) - A 1-click self hosted deployment and maintenance suite for Miniflux. Works on Windows, MacOS and Linux.
 - [miniflux-cleanup](https://github.com/knrdl/miniflux-cleanup) - A Miniflux extension that cleans ads out of your feeds. 
 - [miniflux-injector](https://github.com/Sevichecc/miniflux-injector) - A browser extension that injects search results from the Miniflux bookmark service into search pages such as Google and DuckDuckGo.
 - [Raycast extension for Miniflux](https://www.raycast.com/SevicheCC/miniflux) - A Raycast extension that allows you to quickly access, read, star, mark as read, and save RSS feed entries from Miniflux. 


### PR DESCRIPTION
Added Cloud Seeder (https://github.com/ipv6rslimited/cloudseeder)

Cloud Seeder lets you deploy and maintain Miniflux, including the reverse proxy and all, with just a click on your home computer.

Thank you for the consideration!